### PR TITLE
Fix JSON parse failure in judge

### DIFF
--- a/utils/judge.js
+++ b/utils/judge.js
@@ -25,8 +25,13 @@ Respond ONLY with a raw JSON object:
   if (raw.startsWith("```")) {
     raw = raw.replace(/```json|```/g, "").trim();
   }
-
-  const result = JSON.parse(raw);
+  let result;
+  try {
+    result = JSON.parse(raw);
+  } catch (err) {
+    console.error("Failed to parse judge result", err, raw);
+    result = { helpfulness: null, tone: null, reason: "parse_error", raw };
+  }
   result.timestamp = new Date().toISOString();
   result.id = data.id;
   result.question = data.question;


### PR DESCRIPTION
## Summary
- add error handling to utils/judge.js when OpenAI response isn't valid JSON

## Testing
- `node --check utils/judge.js`

------
https://chatgpt.com/codex/tasks/task_e_68407dff8b8c8321bb17011b53d0311c